### PR TITLE
Add SwiftUI workout tracker skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Personal Workout Tracker
+
+SwiftUI iOS app for tracking workouts and visualizing progress.
+
+## Features
+- One-time setup collecting user info and weekly workout plan
+- Daily workout logging with configurable rest timer
+- Automatic summary and progress storage
+- Progress charts visualizing weight over time with color-coded rep accuracy
+
+## Running
+1. Open the `WorkoutTracker` folder in Xcode 14+.
+2. Ensure your deployment target is iOS 16 or later (for the Charts framework).
+3. Build and run on an iPhone or simulator.
+
+Data persists using `UserDefaults`; no backend required.

--- a/WorkoutTracker/Models/UserProfile.swift
+++ b/WorkoutTracker/Models/UserProfile.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+struct UserProfile: Codable {
+    var name: String
+    var weight: Double
+    var restSeconds: Int
+    var schedule: [Weekday: [ExercisePlan]]
+}
+
+enum Weekday: String, Codable, CaseIterable, Identifiable {
+    case sunday, monday, tuesday, wednesday, thursday, friday, saturday
+    var id: String { rawValue }
+    var display: String { rawValue.capitalized }
+}
+
+struct ExercisePlan: Codable, Identifiable {
+    var id = UUID()
+    var name: String
+    var sets: Int
+    var targetReps: Int
+}

--- a/WorkoutTracker/Models/WorkoutLog.swift
+++ b/WorkoutTracker/Models/WorkoutLog.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+struct WorkoutLog: Codable, Identifiable {
+    var id = UUID()
+    var date: Date
+    var exercises: [ExerciseLog]
+}
+
+struct ExerciseLog: Codable, Identifiable {
+    var id = UUID()
+    var name: String
+    var setLogs: [SetLog]
+    var targetReps: Int
+}
+
+struct SetLog: Codable, Identifiable {
+    var id = UUID()
+    var weight: Double
+    var reps: Int
+}

--- a/WorkoutTracker/PersonalWorkoutTrackerApp.swift
+++ b/WorkoutTracker/PersonalWorkoutTrackerApp.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+
+@main
+struct PersonalWorkoutTrackerApp: App {
+    @StateObject private var store = DataStore()
+    
+    var body: some Scene {
+        WindowGroup {
+            if store.userProfile == nil {
+                SetupView()
+                    .environmentObject(store)
+            } else {
+                TabView {
+                    WorkoutView()
+                        .environmentObject(store)
+                        .tabItem {
+                            Label("Workout", systemImage: "figure.strengthtraining.traditional")
+                        }
+                    ProgressViewScreen()
+                        .environmentObject(store)
+                        .tabItem {
+                            Label("Progress", systemImage: "chart.line.uptrend.xyaxis")
+                        }
+                }
+            }
+        }
+    }
+}
+
+final class DataStore: ObservableObject {
+    @Published var userProfile: UserProfile? {
+        didSet { saveProfile() }
+    }
+    @Published var workoutLogs: [WorkoutLog] = [] {
+        didSet { saveLogs() }
+    }
+    
+    private let profileKey = "userProfile"
+    private let logsKey = "workoutLogs"
+    
+    init() {
+        loadProfile()
+        loadLogs()
+    }
+    
+    func saveWorkoutDay(date: Date, exercises: [ExerciseLog]) {
+        let log = WorkoutLog(date: date, exercises: exercises)
+        workoutLogs.append(log)
+    }
+    
+    // MARK: Persistence
+    private func loadProfile() {
+        guard
+            let data = UserDefaults.standard.data(forKey: profileKey),
+            let profile = try? JSONDecoder().decode(UserProfile.self, from: data)
+        else { return }
+        userProfile = profile
+    }
+    private func saveProfile() {
+        guard let profile = userProfile,
+              let data = try? JSONEncoder().encode(profile) else { return }
+        UserDefaults.standard.set(data, forKey: profileKey)
+    }
+    private func loadLogs() {
+        guard
+            let data = UserDefaults.standard.data(forKey: logsKey),
+            let logs = try? JSONDecoder().decode([WorkoutLog].self, from: data)
+        else { return }
+        workoutLogs = logs
+    }
+    private func saveLogs() {
+        guard let data = try? JSONEncoder().encode(workoutLogs) else { return }
+        UserDefaults.standard.set(data, forKey: logsKey)
+    }
+}

--- a/WorkoutTracker/Views/ProgressViewScreen.swift
+++ b/WorkoutTracker/Views/ProgressViewScreen.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+import Charts
+
+struct ProgressViewScreen: View {
+    @EnvironmentObject var store: DataStore
+    
+    var body: some View {
+        NavigationView {
+            List {
+                ForEach(exerciseNames, id: \.self) { name in
+                    NavigationLink(name) {
+                        ExerciseProgressView(exerciseName: name)
+                            .environmentObject(store)
+                    }
+                }
+            }
+            .navigationTitle("Progress")
+        }
+    }
+    
+    private var exerciseNames: [String] {
+        Set(store.workoutLogs.flatMap { $0.exercises.map { $0.name } }).sorted()
+    }
+}
+
+struct ExerciseProgressView: View {
+    let exerciseName: String
+    @EnvironmentObject var store: DataStore
+    
+    var body: some View {
+        Chart(entries) { entry in
+            LineMark(
+                x: .value("Date", entry.date),
+                y: .value("Weight", entry.maxWeight)
+            )
+            PointMark(
+                x: .value("Date", entry.date),
+                y: .value("Weight", entry.maxWeight)
+            )
+            .foregroundStyle(entry.color)
+        }
+        .padding()
+        .navigationTitle(exerciseName)
+    }
+    
+    private var entries: [ProgressEntry] {
+        store.workoutLogs.compactMap { log in
+            guard let exercise = log.exercises.first(where: { $0.name == exerciseName }) else { return nil }
+            let maxWeight = exercise.setLogs.map(\.$weight).max() ?? 0
+            let avgReps = exercise.setLogs.map(\.$reps).reduce(0, +) / max(1, exercise.setLogs.count)
+            let diff = abs(avgReps - exercise.targetReps)
+            let color: Color = diff >= 5 ? .red : (diff >= 2 ? .yellow : .green)
+            return ProgressEntry(date: log.date, maxWeight: maxWeight, color: color)
+        }
+    }
+}
+
+struct ProgressEntry: Identifiable {
+    let id = UUID()
+    let date: Date
+    let maxWeight: Double
+    let color: Color
+}

--- a/WorkoutTracker/Views/RestTimerView.swift
+++ b/WorkoutTracker/Views/RestTimerView.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+struct RestTimerView: View {
+    let seconds: Int
+    @Environment(\.dismiss) var dismiss
+    @State private var remaining: Int
+    @State private var timer: Timer?
+    
+    init(seconds: Int) {
+        self.seconds = seconds
+        _remaining = State(initialValue: seconds)
+    }
+    
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("Rest")
+                .font(.largeTitle)
+            Text("\(remaining)")
+                .font(.system(size: 72, weight: .bold, design: .rounded))
+            Button("Cancel") { dismiss() }
+        }
+        .onAppear(perform: start)
+        .onDisappear { timer?.invalidate() }
+    }
+    
+    private func start() {
+        timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { t in
+            if remaining > 0 {
+                remaining -= 1
+            } else {
+                t.invalidate()
+                dismiss()
+            }
+        }
+    }
+}

--- a/WorkoutTracker/Views/SetupView.swift
+++ b/WorkoutTracker/Views/SetupView.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+
+struct SetupView: View {
+    @EnvironmentObject var store: DataStore
+    @State private var name: String = ""
+    @State private var weight: String = ""
+    @State private var restSeconds: String = "60"
+    @State private var schedule: [Weekday: [ExercisePlan]] = [:]
+    
+    var body: some View {
+        Form {
+            Section(header: Text("Profile")) {
+                TextField("Name", text: $name)
+                TextField("Weight (lbs)", text: $weight)
+                    .keyboardType(.decimalPad)
+                TextField("Rest Seconds", text: $restSeconds)
+                    .keyboardType(.numberPad)
+            }
+            Section(header: Text("Weekly Schedule")) {
+                ForEach(Weekday.allCases) { day in
+                    NavigationLink(day.display) {
+                        ExerciseDayEditor(day: day, exercises: $schedule[day, default: []])
+                    }
+                }
+            }
+            Button("Save") { saveProfile() }
+                .disabled(name.isEmpty || Double(weight) == nil)
+        }
+        .navigationTitle("Setup")
+    }
+    
+    private func saveProfile() {
+        guard let weightValue = Double(weight), let rest = Int(restSeconds) else { return }
+        let profile = UserProfile(name: name, weight: weightValue, restSeconds: rest, schedule: schedule)
+        store.userProfile = profile
+    }
+}
+
+struct ExerciseDayEditor: View {
+    let day: Weekday
+    @Binding var exercises: [ExercisePlan]
+    @State private var newName: String = ""
+    @State private var sets: String = "3"
+    @State private var reps: String = "12"
+    
+    var body: some View {
+        Form {
+            Section {
+                TextField("Exercise Name", text: $newName)
+                TextField("Sets", text: $sets).keyboardType(.numberPad)
+                TextField("Target Reps", text: $reps).keyboardType(.numberPad)
+                Button("Add") {
+                    guard
+                        !newName.isEmpty,
+                        let setCount = Int(sets),
+                        let repCount = Int(reps)
+                    else { return }
+                    exercises.append(ExercisePlan(name: newName, sets: setCount, targetReps: repCount))
+                    newName = ""
+                }
+            }
+            Section {
+                ForEach(exercises) { exercise in
+                    Text("\(exercise.name) - \(exercise.sets)x\(exercise.targetReps)")
+                }
+                .onDelete { index in
+                    exercises.remove(atOffsets: index)
+                }
+            }
+        }
+        .navigationTitle(day.display)
+    }
+}

--- a/WorkoutTracker/Views/WorkoutView.swift
+++ b/WorkoutTracker/Views/WorkoutView.swift
@@ -1,0 +1,96 @@
+import SwiftUI
+
+struct WorkoutView: View {
+    @EnvironmentObject var store: DataStore
+    @State private var exerciseLogs: [ExerciseLog] = []
+    @State private var showSummary = false
+    
+    private var todayPlan: [ExercisePlan] {
+        guard let profile = store.userProfile else { return [] }
+        let weekday = Weekday.allCases[Calendar.current.component(.weekday, from: Date()) - 1]
+        return profile.schedule[weekday] ?? []
+    }
+    
+    var body: some View {
+        NavigationView {
+            List {
+                ForEach(exerciseLogs.indices, id: \.self) { idx in
+                    ExerciseLogger(log: $exerciseLogs[idx], restSeconds: store.userProfile?.restSeconds ?? 60)
+                }
+            }
+            .navigationTitle("Today's Workout")
+            .toolbar {
+                Button("Finish") { finishWorkout() }
+            }
+            .onAppear {
+                if exerciseLogs.isEmpty {
+                    exerciseLogs = todayPlan.map { plan in
+                        ExerciseLog(name: plan.name, setLogs: Array(repeating: SetLog(weight: 0, reps: 0), count: plan.sets), targetReps: plan.targetReps)
+                    }
+                }
+            }
+            .sheet(isPresented: $showSummary) {
+                WorkoutSummaryView(exercises: exerciseLogs)
+                    .onDisappear { reset() }
+            }
+        }
+    }
+    
+    private func finishWorkout() {
+        store.saveWorkoutDay(date: Date(), exercises: exerciseLogs)
+        showSummary = true
+    }
+    private func reset() {
+        exerciseLogs.removeAll()
+    }
+}
+
+struct ExerciseLogger: View {
+    @Binding var log: ExerciseLog
+    let restSeconds: Int
+    @State private var currentSet = 0
+    @State private var showTimer = false
+    
+    var body: some View {
+        Section(header: Text(log.name)) {
+            ForEach(log.setLogs.indices, id: \.self) { index in
+                HStack {
+                    Text("Set \(index + 1)")
+                    Spacer()
+                    TextField("Wt", value: $log.setLogs[index].weight, format: .number)
+                        .keyboardType(.decimalPad)
+                        .frame(width: 60)
+                    TextField("Reps", value: $log.setLogs[index].reps, format: .number)
+                        .keyboardType(.numberPad)
+                        .frame(width: 50)
+                }
+            }
+            Button("Start Rest Timer") {
+                showTimer = true
+            }
+            .sheet(isPresented: $showTimer) {
+                RestTimerView(seconds: restSeconds)
+            }
+        }
+    }
+}
+
+struct WorkoutSummaryView: View {
+    let exercises: [ExerciseLog]
+    
+    var body: some View {
+        NavigationView {
+            List {
+                ForEach(exercises) { log in
+                    VStack(alignment: .leading) {
+                        Text(log.name).font(.headline)
+                        ForEach(log.setLogs) { set in
+                            Text("Wt: \(set.weight, specifier: "%.0f") lbs - Reps: \(set.reps)")
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Summary")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- scaffold SwiftUI app with setup flow, daily workout logging, rest timer, and progress charts
- store profile and logs in `UserDefaults`
- document running instructions for Xcode

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68c0ebee91e0833391a2953a4b16c0b0