### PR TITLE
Add structured workout day setup with sets and reps

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Streamlit's multipage feature to separate profile setup, workout logging and
 progress visualization into dedicated pages.
 
 ## Features
-- User setup storing name and weekly workout plan
+
+- User setup storing name, workout days, and planned workouts with sets and reps
 - Daily workout logging with date, exercise, weight and reps
 - Progress page showing weight over time for each exercise
 

--- a/data.py
+++ b/data.py
@@ -12,8 +12,14 @@ DATA_DIR.mkdir(exist_ok=True)
 def load_profile() -> dict:
     if PROFILE_FILE.exists():
         with open(PROFILE_FILE) as f:
-            return json.load(f)
-    return {"name": "", "weekly_plan": ""}
+            data = json.load(f)
+    else:
+        data = {}
+    return {
+        "name": data.get("name", ""),
+        "workout_days": data.get("workout_days", []),
+        "workouts": data.get("workouts", {}),
+    }
 
 def save_profile(profile: dict) -> None:
     with open(PROFILE_FILE, "w") as f:

--- a/pages/1_Setup.py
+++ b/pages/1_Setup.py
@@ -5,12 +5,39 @@ from data import load_profile, save_profile
 st.title("User Setup")
 
 profile = load_profile()
+weekdays = [
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday",
+    "Sunday",
+]
+
 with st.form("setup"):
     name = st.text_input("Name", value=profile.get("name", ""))
-    weekly_plan = st.text_area(
-        "Weekly Workout Plan", value=profile.get("weekly_plan", "")
+    workout_days = st.multiselect(
+        "Workout Days", weekdays, default=profile.get("workout_days", [])
     )
+    workouts = {}
+    existing_workouts = profile.get("workouts", {})
+    for day in workout_days:
+        st.markdown(f"### {day}")
+        cols = st.columns(3)
+        w = existing_workouts.get(day, {})
+        workout_name = cols[0].text_input(
+            "Workout", value=w.get("name", ""), key=f"{day}_name"
+        )
+        sets = cols[1].number_input(
+            "Sets", min_value=1, step=1, value=int(w.get("sets", 1) or 1), key=f"{day}_sets"
+        )
+        reps = cols[2].number_input(
+            "Reps", min_value=1, step=1, value=int(w.get("reps", 1) or 1), key=f"{day}_reps"
+        )
+        workouts[day] = {"name": workout_name, "sets": sets, "reps": reps}
     submitted = st.form_submit_button("Save")
+
 if submitted:
-    save_profile({"name": name, "weekly_plan": weekly_plan})
+    save_profile({"name": name, "workout_days": workout_days, "workouts": workouts})
     st.success("Profile saved")


### PR DESCRIPTION
## Summary
- Collect workout days and exercises with sets and reps during user setup
- Store profile with workout days and exercises in data layer
- Update documentation to reflect day-by-day setup

## Testing
- `python -m py_compile app.py data.py pages/1_Setup.py pages/2_Log_Workout.py pages/3_Progress.py`

------
https://chatgpt.com/codex/tasks/task_e_68c1d3afee1083338d16707e6fa5e4f5