### PR TITLE
Improve workout setup and logging with set-level tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,8 @@ progress visualization into dedicated pages.
 
 ## Features
 
-
-- User setup storing name, workout days, and multiple planned workouts per day with sets and reps
-- Daily workout logging that automatically loads today's exercises and reveals each one as you complete it
-- User setup storing name, workout days, and planned workouts with sets and reps
-- Daily workout logging with date, exercise, weight and reps
+- User setup storing name, rest timer, workout days, and multiple planned workouts per day with sets and reps
+- Daily workout logging goes set-by-set with an optional rest timer between sets
 - Progress page showing weight over time for each exercise
 
 ## Running

--- a/data.py
+++ b/data.py
@@ -29,10 +29,7 @@ def load_profile() -> dict:
         "name": data.get("name", ""),
         "workout_days": data.get("workout_days", []),
         "workouts": workouts,
-    return {
-        "name": data.get("name", ""),
-        "workout_days": data.get("workout_days", []),
-        "workouts": data.get("workouts", {}),
+        "rest_seconds": data.get("rest_seconds", 0),
     }
 
 def save_profile(profile: dict) -> None:

--- a/pages/1_Setup.py
+++ b/pages/1_Setup.py
@@ -16,7 +16,13 @@ weekdays = [
 ]
 
 with st.form("setup"):
-    name = st.text_input("Name", value=profile.get("name", ""))
+    user_name = st.text_input("Name", value=profile.get("name", ""))
+    rest_seconds = st.number_input(
+        "Rest time between sets (seconds)",
+        min_value=0,
+        step=1,
+        value=int(profile.get("rest_seconds", 0)),
+    )
     workout_days = st.multiselect(
         "Workout Days", weekdays, default=profile.get("workout_days", [])
     )
@@ -36,7 +42,7 @@ with st.form("setup"):
             cols = st.columns(3)
             w = existing_workouts.get(day, [])
             w_i = w[i] if i < len(w) else {}
-            name = cols[0].text_input(
+            workout_name = cols[0].text_input(
                 "Workout",
                 value=w_i.get("name", ""),
                 key=f"{day}_{i}_name",
@@ -55,22 +61,17 @@ with st.form("setup"):
                 value=int(w_i.get("reps", 1) or 1),
                 key=f"{day}_{i}_reps",
             )
-            day_workouts.append({"name": name, "sets": sets, "reps": reps})
+            day_workouts.append({"name": workout_name, "sets": sets, "reps": reps})
         workouts[day] = day_workouts
-        cols = st.columns(3)
-        w = existing_workouts.get(day, {})
-        workout_name = cols[0].text_input(
-            "Workout", value=w.get("name", ""), key=f"{day}_name"
-        )
-        sets = cols[1].number_input(
-            "Sets", min_value=1, step=1, value=int(w.get("sets", 1) or 1), key=f"{day}_sets"
-        )
-        reps = cols[2].number_input(
-            "Reps", min_value=1, step=1, value=int(w.get("reps", 1) or 1), key=f"{day}_reps"
-        )
-        workouts[day] = {"name": workout_name, "sets": sets, "reps": reps}
     submitted = st.form_submit_button("Save")
 
 if submitted:
-    save_profile({"name": name, "workout_days": workout_days, "workouts": workouts})
+    save_profile(
+        {
+            "name": user_name,
+            "rest_seconds": rest_seconds,
+            "workout_days": workout_days,
+            "workouts": workouts,
+        }
+    )
     st.success("Profile saved")

--- a/pages/2_Log_Workout.py
+++ b/pages/2_Log_Workout.py
@@ -1,4 +1,5 @@
 import datetime
+import time
 import pandas as pd
 import streamlit as st
 
@@ -7,26 +8,32 @@ from data import load_logs, load_profile, save_logs
 st.title("Log Workout")
 
 profile = load_profile()
+rest_seconds = profile.get("rest_seconds", 0)
 today = datetime.datetime.now().strftime("%A")
 day_workouts = profile.get("workouts", {}).get(today, [])
 
 if st.session_state.get("workout_day") != today:
     st.session_state.workout_day = today
     st.session_state.workout_index = 0
+    st.session_state.set_index = 0
 
 logs = load_logs()
 
 if not day_workouts:
     st.info("No workouts scheduled for today.")
 else:
-    idx = st.session_state.get("workout_index", 0)
-    if idx < len(day_workouts):
-        w = day_workouts[idx]
-        st.subheader(f"{w['name']} - {w['sets']} sets x {w['reps']} reps")
+    w_idx = st.session_state.get("workout_index", 0)
+    if w_idx < len(day_workouts):
+        w = day_workouts[w_idx]
+        set_idx = st.session_state.get("set_index", 0)
+        total_sets = int(w.get("sets", 1))
+        st.subheader(
+            f"{w['name']} - Set {set_idx + 1} of {total_sets} ({w['reps']} reps)"
+        )
         with st.form("log"):
             weight = st.number_input("Weight", min_value=0.0, step=1.0)
             reps = st.number_input("Reps", min_value=0, step=1, value=w["reps"])
-            submitted = st.form_submit_button("Complete Workout")
+            submitted = st.form_submit_button("Log Set")
         if submitted:
             new_log = {
                 "date": pd.to_datetime(datetime.date.today()),
@@ -36,8 +43,21 @@ else:
             }
             logs = pd.concat([logs, pd.DataFrame([new_log])], ignore_index=True)
             save_logs(logs)
-            st.session_state.workout_index = idx + 1
-            st.success(f"Completed {w['name']}")
+            set_idx += 1
+            if set_idx >= total_sets:
+                st.session_state.workout_index = w_idx + 1
+                st.session_state.set_index = 0
+                st.success(f"Completed {w['name']}")
+            else:
+                st.session_state.set_index = set_idx
+                st.success(f"Logged set {set_idx} of {w['name']}")
+            if rest_seconds > 0 and set_idx < total_sets:
+                placeholder = st.empty()
+                for remaining in range(rest_seconds, 0, -1):
+                    placeholder.metric("Rest", f"{remaining}s")
+                    time.sleep(1)
+                placeholder.empty()
+            st.experimental_rerun()
     else:
         st.success(
             "All workouts completed for today! Head to the Progress page to review your performance."


### PR DESCRIPTION
## Summary
- fix setup page bugs and support defining a rest timer per user
- log workouts set-by-set with automatic rest countdown
- document rest timer and set-based logging

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c1dd5f58f08333b6da5d06d1bbe816